### PR TITLE
Fix marketplace icon

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,5 +17,5 @@ runs:
   using: 'node20'
   main: 'dist/index.js'
 branding:
-  icon: 'brain'
+  icon: 'cpu'
   color: 'purple'


### PR DESCRIPTION
Use 'cpu' instead of 'brain' — GitHub Marketplace requires Feather icons.